### PR TITLE
Add intro screen and draw animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import StationCard from './components/StationCard';
 import subwayRaw from './assets/subway.json';
 import { useRandomStation } from './hooks/useRandomStation';
@@ -57,32 +57,100 @@ function App() {
   const dataset = subwayRaw as RawSubwayData;
 
   const stations = useMemo(() => buildStationList(dataset), [dataset]);
-  const { currentStation, drawStation } = useRandomStation(stations);
+  const { currentStation, drawStation } = useRandomStation(stations, {
+    autoDrawOnMount: false,
+  });
+  const [hasStarted, setHasStarted] = useState(false);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [displayedStation, setDisplayedStation] = useState<Station | null>(null);
+  const latestStationRef = useRef<Station | null>(null);
+  const revealTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    latestStationRef.current = currentStation;
+  }, [currentStation]);
+
+  useEffect(() => () => {
+    if (revealTimeoutRef.current) {
+      clearTimeout(revealTimeoutRef.current);
+    }
+  }, []);
+
+  const handleDraw = () => {
+    if (stations.length === 0) {
+      return;
+    }
+
+    setHasStarted(true);
+    setIsDrawing(true);
+    setDisplayedStation(null);
+    drawStation();
+
+    if (revealTimeoutRef.current) {
+      clearTimeout(revealTimeoutRef.current);
+    }
+
+    revealTimeoutRef.current = setTimeout(() => {
+      setDisplayedStation(latestStationRef.current ?? null);
+      setIsDrawing(false);
+    }, 900);
+  };
 
   return (
     <div className="app">
       <header className="app__header">
         <h1>랜덤 지하철 역 뽑기</h1>
         <p>
-          대한민국의 모든 지하철 역 중에서 오늘의 랜덤 추천 역을 만나보세요. 클릭 한 번으로 새로운 역을 발견할 수
-          있습니다.
+          노선도 위에서 손가락이 방황하는 날, 대신 버튼을 눌러 오늘의 행선지를 추천받아보세요. 어쩌면 집 앞 역이
+          다시 나올지도, 전혀 가보지 못한 곳이 나올지도 몰라요.
         </p>
         <p className="app__meta">
           총 <strong>{stations.length}</strong>개 역 정보 수록 · 데이터 버전 {dataset.VERSION}
         </p>
       </header>
 
-      <main className="app__main">
-        {currentStation ? (
-          <StationCard station={currentStation} />
-        ) : (
-          <p className="app__placeholder">역 정보를 불러오고 있습니다...</p>
+      <main className="app__main" aria-live="polite">
+        {!hasStarted && (
+          <section className="app__intro">
+            <p>오늘은 어떤 역이 기다리고 있을까요? 무작정 떠나고 싶은 마음에 노선도를 덮어놓았습니다.</p>
+            <p>
+              역 뽑기 버튼을 누르면 잠깐의 셔플 끝에 추천 역이 등장합니다. 마음속에서 &ldquo;이번엔 어디쯤일까?&rdquo;라는
+              설렘이 피어오를 거예요.
+            </p>
+            <p className="app__intro-note">자, 준비되셨다면 버튼을 눌러 랜덤 여정을 시작해볼까요?</p>
+          </section>
+        )}
+
+        {hasStarted && isDrawing && (
+          <section className="app__drawing">
+            <div className="app__drawing-spinner" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </div>
+            <p>잠시만요! 오늘의 행선지를 섞는 중입니다...</p>
+          </section>
+        )}
+
+        {hasStarted && !isDrawing && displayedStation && (
+          <div className="app__station-wrapper">
+            <StationCard station={displayedStation} />
+          </div>
+        )}
+
+        {hasStarted && !isDrawing && !displayedStation && (
+          <p className="app__placeholder">추천할 역을 찾지 못했어요. 다시 시도해 주세요.</p>
         )}
       </main>
 
       <footer className="app__footer">
-        <button type="button" className="app__button" onClick={drawStation}>
-          다른 역 뽑기
+        <button
+          type="button"
+          className="app__button"
+          onClick={handleDraw}
+          disabled={isDrawing || stations.length === 0}
+        >
+          {hasStarted ? '다른 역 뽑기' : '오늘의 역 뽑기'}
         </button>
         <a className="app__data-link" href={dataset.URL} target="_blank" rel="noreferrer">
           데이터 출처 보기

--- a/src/hooks/useRandomStation.ts
+++ b/src/hooks/useRandomStation.ts
@@ -3,6 +3,7 @@ import type { Station } from '../types/subway';
 
 export interface UseRandomStationOptions {
   avoidImmediateRepeat?: boolean;
+  autoDrawOnMount?: boolean;
 }
 
 interface UseRandomStationResult {
@@ -12,7 +13,10 @@ interface UseRandomStationResult {
 
 export const useRandomStation = (
   stations: Station[],
-  { avoidImmediateRepeat = true }: UseRandomStationOptions = {}
+  {
+    avoidImmediateRepeat = true,
+    autoDrawOnMount = true,
+  }: UseRandomStationOptions = {}
 ): UseRandomStationResult => {
   const [currentStation, setCurrentStation] = useState<Station | null>(null);
 
@@ -41,8 +45,10 @@ export const useRandomStation = (
   }, [avoidImmediateRepeat, stations]);
 
   useEffect(() => {
-    drawStation();
-  }, [drawStation]);
+    if (autoDrawOnMount) {
+      drawStation();
+    }
+  }, [autoDrawOnMount, drawStation]);
 
   return { currentStation, drawStation };
 };

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -40,8 +40,65 @@
 .app__main {
   width: 100%;
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+  gap: 24px;
   padding: 0 16px;
+  min-height: 280px;
+  text-align: center;
+}
+
+.app__intro {
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  line-height: 1.6;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.app__intro-note {
+  font-weight: 600;
+  color: #facc15;
+}
+
+.app__drawing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  min-height: 180px;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.app__drawing-spinner {
+  display: flex;
+  gap: 10px;
+}
+
+.app__drawing-spinner span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: linear-gradient(120deg, #f97316, #f472b6);
+  opacity: 0.6;
+  animation: app-draw-bounce 0.8s ease-in-out infinite;
+}
+
+.app__drawing-spinner span:nth-child(2) {
+  animation-delay: 0.12s;
+}
+
+.app__drawing-spinner span:nth-child(3) {
+  animation-delay: 0.24s;
+}
+
+.app__station-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  animation: app-fade-in-up 0.4s ease forwards;
 }
 
 .app__placeholder {
@@ -79,6 +136,13 @@
   transform: translateY(0);
 }
 
+.app__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .app__data-link {
   color: rgba(248, 250, 252, 0.75);
   font-size: 0.95rem;
@@ -89,6 +153,31 @@
   text-decoration: underline;
 }
 
+@keyframes app-draw-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.6;
+  }
+
+  50% {
+    transform: translateY(-8px);
+    opacity: 1;
+  }
+}
+
+@keyframes app-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 16px, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
 @media (max-width: 640px) {
   .app {
     padding: 32px 12px 48px;
@@ -96,5 +185,10 @@
 
   .app__header {
     margin-bottom: 24px;
+  }
+
+  .app__main {
+    min-height: 240px;
+    gap: 20px;
   }
 }


### PR DESCRIPTION
## Summary
- add an introductory state and animated drawing flow before revealing the station card
- allow opting out of the initial draw in `useRandomStation` so the reveal waits for the first button press
- style the new states with supporting animations, layout tweaks, and button loading feedback

## Testing
- npm run build *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0e58f8d88323937151b6c6d96482