### PR TITLE
Refine result carousel interactions and station display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,13 @@
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type CSSProperties,
+  type KeyboardEvent,
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import StationCard from './components/StationCard';
 import subwayRaw from './assets/subway.json';
 import { useRandomStation } from './hooks/useRandomStation';
@@ -55,7 +64,7 @@ const buildStationList = (data: RawSubwayData): Station[] => {
 };
 
 function App() {
-  const dataset = subwayRaw as RawSubwayData;
+  const dataset = subwayRaw as unknown as RawSubwayData;
 
   const stations = useMemo(() => buildStationList(dataset), [dataset]);
   const maxSelectable = Math.max(MIN_DRAW_COUNT, Math.min(MAX_DRAW_COUNT, stations.length || MIN_DRAW_COUNT));
@@ -68,6 +77,7 @@ function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [isDrawing, setIsDrawing] = useState(false);
   const [displayedStations, setDisplayedStations] = useState<Station[]>([]);
+  const [activeStationIndex, setActiveStationIndex] = useState(0);
   const [loadingPreview, setLoadingPreview] = useState<Station[]>([]);
   const latestStationsRef = useRef<Station[]>([]);
   const revealTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -174,6 +184,7 @@ function App() {
 
     setHasStarted(true);
     setDisplayedStations([]);
+    setActiveStationIndex(0);
     setActiveDrawCount(nextCount);
     setLoadingPreview(initialPreview);
     setIsDrawing(true);
@@ -202,6 +213,46 @@ function App() {
       ? '다른 역들 다시 뽑기'
       : '다른 역 다시 뽑기'
     : '오늘의 역 뽑기';
+
+  const handlePreviousStation = () => {
+    if (displayedStations.length <= 1) {
+      return;
+    }
+
+    setActiveStationIndex((prev) => (prev === 0 ? displayedStations.length - 1 : prev - 1));
+  };
+
+  const handleNextStation = () => {
+    if (displayedStations.length <= 1) {
+      return;
+    }
+
+    setActiveStationIndex((prev) => (prev === displayedStations.length - 1 ? 0 : prev + 1));
+  };
+
+  useEffect(() => {
+    setActiveStationIndex(0);
+  }, [displayedStations]);
+
+  const handleSelectStation = (index: number) => {
+    setActiveStationIndex(index);
+  };
+
+  const handleCarouselKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (displayedStations.length <= 1) {
+      return;
+    }
+
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      handlePreviousStation();
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      handleNextStation();
+    }
+  };
+
+  const hasResults = displayedStations.length > 0;
 
   return (
     <div className="app">
@@ -250,16 +301,51 @@ function App() {
           </section>
         )}
 
-        {hasStarted && !isDrawing && displayedStations.length > 0 && (
+        {hasStarted && !isDrawing && hasResults && (
           <section className="app__results">
             <p className="app__results-title">
               오늘의 추천 역{displayedStations.length > 1 ? ` ${displayedStations.length}곳` : ''}입니다!
             </p>
-            <div className="app__station-grid">
-              {displayedStations.map((station) => (
-                <StationCard key={station.id} station={station} />
-              ))}
+            <div className="app__results-carousel">
+              <div className="app__carousel-stage" role="group" aria-label="추천된 역 목록">
+                {displayedStations.map((station, index) => {
+                  const offset = index - activeStationIndex;
+                  const distance = Math.abs(offset);
+                  const direction = Math.sign(offset);
+                  const translatePercent = direction === 0 ? 0 : direction * Math.min(distance * 36, 96);
+                  const scale = index === activeStationIndex ? 1 : Math.max(0.82, 1 - Math.min(distance, 2) * 0.08);
+                  const opacity = index === activeStationIndex ? 1 : Math.max(0.2, 1 - distance * 0.32);
+                  const cardStyle: CSSProperties = {
+                    transform: `translateX(${translatePercent}%) scale(${scale})`,
+                    opacity,
+                    zIndex: Math.max(1, displayedStations.length - distance),
+                  };
+                  const ariaLabel = station.lines.length
+                    ? `${station.name} (${station.lines.join(', ')}) 역 자세히 보기`
+                    : `${station.name} 역 자세히 보기`;
+
+                  return (
+                    <button
+                      key={station.id}
+                      type="button"
+                      className={`app__carousel-card${index === activeStationIndex ? ' app__carousel-card--active' : ''}`}
+                      onClick={() => handleSelectStation(index)}
+                      aria-label={ariaLabel}
+                      aria-current={index === activeStationIndex ? 'true' : undefined}
+                      onKeyDown={handleCarouselKeyDown}
+                      style={cardStyle}
+                    >
+                      <StationCard station={station} />
+                    </button>
+                  );
+                })}
+              </div>
             </div>
+            {displayedStations.length > 1 && (
+              <p className="app__results-indicator" aria-live="polite">
+                {activeStationIndex + 1} / {displayedStations.length}
+              </p>
+            )}
           </section>
         )}
 

--- a/src/components/StationCard.css
+++ b/src/components/StationCard.css
@@ -14,28 +14,28 @@
 .station-card__header {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-}
-
-.station-card__header h2 {
-  font-size: 2rem;
-  margin: 0;
-  font-weight: 700;
-}
-
-.station-card__lines {
-  display: flex;
-  flex-wrap: wrap;
   gap: 8px;
 }
 
-.station-card__line-chip {
-  background: linear-gradient(120deg, #3b82f6, #22d3ee);
-  color: #ffffff;
-  padding: 6px 12px;
-  border-radius: 9999px;
-  font-size: 0.875rem;
+.station-card__title {
+  margin: 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4em;
+  font-size: clamp(1.75rem, 4vw, 2.2rem);
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.station-card__name {
+  color: #0f172a;
+}
+
+.station-card__line {
+  font-size: clamp(1.05rem, 3vw, 1.2rem);
   font-weight: 600;
+  color: #475569;
 }
 
 .station-card__names {
@@ -77,7 +77,7 @@
     border-radius: 12px;
   }
 
-  .station-card__header h2 {
+  .station-card__title {
     font-size: 1.75rem;
   }
 }

--- a/src/components/StationCard.tsx
+++ b/src/components/StationCard.tsx
@@ -5,23 +5,18 @@ interface StationCardProps {
   station: Station;
 }
 
-const formatLines = (lines: string[]) => lines.join(', ');
-
 export function StationCard({ station }: StationCardProps) {
   const hasInternationalNames =
     station.englishName || station.chineseName || station.japaneseName;
+  const lineLabel = station.lines.length > 0 ? station.lines.join(', ') : '';
 
   return (
     <article className="station-card">
       <header className="station-card__header">
-        <h2>{station.name}</h2>
-        <div className="station-card__lines">
-          {station.lines.map((line) => (
-            <span key={line} className="station-card__line-chip">
-              {line}
-            </span>
-          ))}
-        </div>
+        <h2 className="station-card__title">
+          <span className="station-card__name">{station.name}</span>
+          {lineLabel && <span className="station-card__line">({lineLabel})</span>}
+        </h2>
       </header>
 
       {hasInternationalNames && (
@@ -59,10 +54,6 @@ export function StationCard({ station }: StationCardProps) {
           <span>
             {station.latitude.toFixed(6)}, {station.longitude.toFixed(6)}
           </span>
-        </p>
-        <p>
-          <strong>호선</strong>
-          <span>{formatLines(station.lines)}</span>
         </p>
       </section>
     </article>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
+import App from './App';
 import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -171,14 +171,78 @@
   color: rgba(248, 250, 252, 0.95);
 }
 
-.app__station-grid {
+
+.app__results-carousel {
   width: 100%;
-  max-width: 1040px;
+  display: flex;
+  justify-content: center;
+}
+
+.app__carousel-stage {
+  --carousel-card-width: clamp(280px, 64vw, 520px);
+  width: min(100%, 820px);
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 24px;
-  justify-items: center;
-  animation: app-fade-in-up 0.4s ease forwards;
+  place-items: center;
+  position: relative;
+  padding: 12px 0 28px;
+  overflow: visible;
+}
+
+.app__carousel-card {
+  grid-area: 1 / 1;
+  width: var(--carousel-card-width);
+  max-width: 100%;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  display: block;
+  transition: transform 0.45s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.45s ease, filter 0.45s ease;
+  color: inherit;
+}
+
+.app__carousel-card:focus {
+  outline: none;
+}
+
+.app__carousel-card:focus-visible {
+  outline: 3px solid rgba(250, 204, 21, 0.75);
+  outline-offset: 8px;
+}
+
+.app__carousel-card--active {
+  cursor: default;
+  filter: drop-shadow(0 24px 44px rgba(15, 23, 42, 0.35));
+}
+
+.app__carousel-card:not(.app__carousel-card--active) {
+  filter: drop-shadow(0 16px 32px rgba(15, 23, 42, 0.18));
+}
+
+.app__carousel-card:not(.app__carousel-card--active):hover {
+  filter: drop-shadow(0 20px 40px rgba(15, 23, 42, 0.28));
+}
+
+.app__results-indicator {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.72);
+}
+
+@media (max-width: 720px) {
+  .app__carousel-stage {
+    --carousel-card-width: clamp(240px, 78vw, 460px);
+    padding: 8px 0 24px;
+  }
+}
+
+@media (max-width: 520px) {
+  .app__carousel-stage {
+    --carousel-card-width: min(90vw, 420px);
+    padding: 4px 0 20px;
+  }
 }
 
 .app__placeholder {


### PR DESCRIPTION
## Summary
- display each recommended station card alongside lightly faded neighbors and allow direct card selection instead of arrow buttons
- surface subway line names next to each station title while keeping international name and metadata sections intact
- refresh carousel styling to support the overlapping deck layout and updated typography for the station header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2855fcdc8323943201a879a0ecb1