### PR TITLE
Add Naver Map integration to station cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_NAVER_MAP_CLIENT_ID=your-naver-map-client-id

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.dist
+.env
+.env.*
+!.env.example
+dist
+.vite
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ npm install
 npm run dev
 ```
 
+## 환경 변수 설정
+
+네이버 지도 API를 사용하려면 프로젝트 루트에 있는 `.env.example`을 참고하여 `.env` 파일을 생성하고 발급받은 클라이언트 ID를 입력하세요.
+
+```bash
+cp .env.example .env
+# .env 파일을 열어 실제 발급받은 키로 값을 바꿔주세요
+VITE_NAVER_MAP_CLIENT_ID=실제-네이버-지도-클라이언트-ID
+```
+
+지도 키는 가능하면 사용 도메인을 제한하여 관리하고, 배포 환경에서도 동일한 환경 변수를 주입해야 합니다.
+
 ## 프로덕션 빌드
 ```bash
 npm run build

--- a/src/components/NaverMap.css
+++ b/src/components/NaverMap.css
@@ -1,0 +1,39 @@
+.naver-map {
+  position: relative;
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #e2e8f0, #cbd5f5);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.naver-map__canvas {
+  width: 100%;
+  height: 100%;
+  min-height: 200px;
+}
+
+.naver-map__status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 16px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #ffffff;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.naver-map__status--error {
+  background: rgba(220, 38, 38, 0.78);
+}
+
+@media (max-width: 480px) {
+  .naver-map {
+    border-radius: 10px;
+  }
+}

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useRef, useState } from 'react';
+import './NaverMap.css';
+
+type NaverLatLng = {
+  lat(): number;
+  lng(): number;
+};
+
+type NaverMapInstance = {
+  setCenter(latLng: NaverLatLng): void;
+  setZoom?(zoom: number): void;
+};
+
+type NaverMarkerInstance = {
+  setPosition(latLng: NaverLatLng): void;
+  setMap?(map: NaverMapInstance | null): void;
+  setTitle?(title: string): void;
+};
+
+type NaverMapOptions = {
+  center: NaverLatLng;
+  zoom?: number;
+  [key: string]: unknown;
+};
+
+type NaverMarkerOptions = {
+  position: NaverLatLng;
+  map?: NaverMapInstance | null;
+  title?: string;
+  [key: string]: unknown;
+};
+
+type NaverMapsAPI = {
+  Map: new (element: HTMLElement, options: NaverMapOptions) => NaverMapInstance;
+  LatLng: new (latitude: number, longitude: number) => NaverLatLng;
+  Marker: new (options: NaverMarkerOptions) => NaverMarkerInstance;
+};
+
+declare global {
+  interface Window {
+    naver?: {
+      maps?: NaverMapsAPI;
+    };
+  }
+}
+
+const NAVER_MAP_CLIENT_ID = import.meta.env.VITE_NAVER_MAP_CLIENT_ID;
+const NAVER_MAP_SCRIPT_ID = 'naver-maps-sdk';
+let naverMapsLoader: Promise<NaverMapsAPI> | null = null;
+
+function loadNaverMaps(): Promise<NaverMapsAPI> {
+  if (typeof window === 'undefined') {
+    return Promise.reject(
+      new Error('브라우저 환경에서만 네이버 지도를 사용할 수 있습니다.'),
+    );
+  }
+
+  if (window.naver?.maps) {
+    return Promise.resolve(window.naver.maps);
+  }
+
+  if (naverMapsLoader) {
+    return naverMapsLoader;
+  }
+
+  if (!NAVER_MAP_CLIENT_ID) {
+    return Promise.reject(
+      new Error('네이버 지도 클라이언트 ID가 설정되지 않았습니다.'),
+    );
+  }
+
+  naverMapsLoader = new Promise((resolve, reject) => {
+    const existingScript = document.getElementById(
+      NAVER_MAP_SCRIPT_ID,
+    ) as HTMLScriptElement | null;
+
+    const handleLoad = () => {
+      if (window.naver?.maps) {
+        resolve(window.naver.maps);
+      } else {
+        naverMapsLoader = null;
+        reject(new Error('네이버 지도 SDK를 초기화하지 못했습니다.'));
+      }
+    };
+
+    const handleError = (target?: HTMLScriptElement) => {
+      if (target) {
+        target.remove();
+      }
+      naverMapsLoader = null;
+      reject(new Error('네이버 지도 SDK 로드 중 오류가 발생했습니다.'));
+    };
+
+    if (existingScript) {
+      existingScript.addEventListener('load', handleLoad, { once: true });
+      existingScript.addEventListener(
+        'error',
+        () => handleError(existingScript),
+        { once: true },
+      );
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = NAVER_MAP_SCRIPT_ID;
+    script.src = `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${encodeURIComponent(
+      NAVER_MAP_CLIENT_ID,
+    )}`;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener(
+      'load',
+      () => {
+        script.dataset.loaded = 'true';
+        handleLoad();
+      },
+      { once: true },
+    );
+    script.addEventListener('error', () => handleError(script), {
+      once: true,
+    });
+
+    document.head.appendChild(script);
+  });
+
+  return naverMapsLoader;
+}
+
+interface NaverMapProps {
+  latitude: number;
+  longitude: number;
+  zoom?: number;
+  markerLabel?: string;
+  height?: number | string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function NaverMap({
+  latitude,
+  longitude,
+  zoom = 16,
+  markerLabel,
+  height = 240,
+  className,
+  ariaLabel,
+}: NaverMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapInstanceRef = useRef<NaverMapInstance | null>(null);
+  const markerInstanceRef = useRef<NaverMarkerInstance | null>(null);
+  const [hasEnteredView, setHasEnteredView] = useState(false);
+  const [mapsApi, setMapsApi] = useState<NaverMapsAPI | null>(null);
+  const [isScriptLoading, setIsScriptLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const target = containerRef.current;
+
+    if (!target || typeof window === 'undefined') {
+      return;
+    }
+
+    if (!('IntersectionObserver' in window)) {
+      setHasEnteredView(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setHasEnteredView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '120px 0px' },
+    );
+
+    observer.observe(target);
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!hasEnteredView || mapsApi) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsScriptLoading(true);
+
+    loadNaverMaps()
+      .then((api) => {
+        if (cancelled) {
+          return;
+        }
+        setMapsApi(api);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('지도를 불러오는 중 오류가 발생했습니다.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsScriptLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasEnteredView, mapsApi]);
+
+  useEffect(() => {
+    if (!mapsApi || !containerRef.current) {
+      return;
+    }
+
+    const mapContainer = containerRef.current;
+    const position = new mapsApi.LatLng(latitude, longitude);
+
+    if (!mapInstanceRef.current) {
+      mapInstanceRef.current = new mapsApi.Map(mapContainer, {
+        center: position,
+        zoom,
+      });
+    } else {
+      mapInstanceRef.current.setCenter(position);
+      if (typeof zoom === 'number' && mapInstanceRef.current.setZoom) {
+        mapInstanceRef.current.setZoom(zoom);
+      }
+    }
+
+    if (!markerInstanceRef.current) {
+      markerInstanceRef.current = new mapsApi.Marker({
+        position,
+        map: mapInstanceRef.current,
+        title: markerLabel,
+      });
+    } else {
+      markerInstanceRef.current.setPosition(position);
+      if (markerLabel && markerInstanceRef.current.setTitle) {
+        markerInstanceRef.current.setTitle(markerLabel);
+      }
+    }
+  }, [latitude, longitude, zoom, markerLabel, mapsApi]);
+
+  useEffect(() => {
+    return () => {
+      if (markerInstanceRef.current?.setMap) {
+        markerInstanceRef.current.setMap(null);
+      }
+      markerInstanceRef.current = null;
+      mapInstanceRef.current = null;
+    };
+  }, []);
+
+  const resolvedHeight =
+    typeof height === 'number' ? `${height}px` : height || '240px';
+  const mapClassName = ['naver-map', className].filter(Boolean).join(' ');
+  const shouldShowStatus = isScriptLoading || !!error;
+  const statusMessage = error ?? '지도를 불러오는 중입니다...';
+
+  return (
+    <div
+      className={mapClassName}
+      style={{ height: resolvedHeight }}
+      aria-label={ariaLabel}
+      role={ariaLabel ? 'region' : undefined}
+    >
+      <div
+        ref={containerRef}
+        className="naver-map__canvas"
+        style={{ height: resolvedHeight }}
+        aria-hidden={shouldShowStatus}
+      />
+      {shouldShowStatus && (
+        <div
+          className={`naver-map__status${error ? ' naver-map__status--error' : ''}`}
+          role={error ? 'alert' : 'status'}
+        >
+          {statusMessage}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default NaverMap;

--- a/src/components/StationCard.css
+++ b/src/components/StationCard.css
@@ -86,6 +86,10 @@
   color: #0f172a;
 }
 
+.station-card__map {
+  width: 100%;
+}
+
 @media (max-width: 480px) {
   .station-card {
     padding: 20px;

--- a/src/components/StationCard.tsx
+++ b/src/components/StationCard.tsx
@@ -1,4 +1,5 @@
 import type { Station } from '../types/subway';
+import { NaverMap } from './NaverMap';
 import './StationCard.css';
 
 interface StationCardProps {
@@ -10,6 +11,11 @@ export function StationCard({ station }: StationCardProps) {
     station.englishName || station.chineseName || station.japaneseName;
   const uniqueLines = Array.from(new Set(station.lines));
   const hasLines = uniqueLines.length > 0;
+  const hasCoordinates =
+    Number.isFinite(station.latitude) && Number.isFinite(station.longitude);
+  const formattedCoordinates = hasCoordinates
+    ? `${station.latitude.toFixed(6)}, ${station.longitude.toFixed(6)}`
+    : '위치 정보를 불러올 수 없습니다';
 
   return (
     <article className="station-card">
@@ -60,11 +66,19 @@ export function StationCard({ station }: StationCardProps) {
         )}
         <p>
           <strong>위치</strong>
-          <span>
-            {station.latitude.toFixed(6)}, {station.longitude.toFixed(6)}
-          </span>
+          <span>{formattedCoordinates}</span>
         </p>
       </section>
+      {hasCoordinates && (
+        <div className="station-card__map">
+          <NaverMap
+            latitude={station.latitude}
+            longitude={station.longitude}
+            markerLabel={station.name}
+            ariaLabel={`${station.name} 위치 지도`}
+          />
+        </div>
+      )}
     </article>
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_NAVER_MAP_CLIENT_ID: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add a lazily loaded Naver Map component and show the station location with a marker inside each StationCard
- configure environment variables and docs so the Naver map client ID can be supplied safely
- add supporting styles, typings, and gitignore entries for the new map feature

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc31e03ac08323a0b2da2f076dca87