### PR TITLE
Adjust station card search link styling

### DIFF
--- a/src/components/StationCard.css
+++ b/src/components/StationCard.css
@@ -88,6 +88,56 @@
 
 .station-card__map {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.station-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.station-card__search-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 9999px;
+  background: linear-gradient(120deg, #f97316, #f43f5e);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.station-card__search-link:hover,
+.station-card__search-link:focus-visible {
+  background: linear-gradient(120deg, #ea580c, #e11d48);
+  box-shadow: 0 14px 28px rgba(234, 88, 12, 0.28);
+  transform: translateY(-1px);
+}
+
+.station-card__search-link:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.45);
+  outline-offset: 3px;
+}
+
+.station-card__search-link-icon {
+  display: inline-flex;
+  font-size: 1.1em;
+  line-height: 1;
+  transition: transform 0.2s ease;
+}
+
+.station-card__search-link:hover .station-card__search-link-icon,
+.station-card__search-link:focus-visible .station-card__search-link-icon {
+  transform: translateX(3px);
 }
 
 @media (max-width: 480px) {

--- a/src/components/StationCard.tsx
+++ b/src/components/StationCard.tsx
@@ -13,6 +13,14 @@ export function StationCard({ station }: StationCardProps) {
   const hasLines = uniqueLines.length > 0;
   const hasCoordinates =
     Number.isFinite(station.latitude) && Number.isFinite(station.longitude);
+  const trimmedStationName = station.name.trim();
+  const stationNameWithSuffix = trimmedStationName.endsWith('역')
+    ? trimmedStationName
+    : `${trimmedStationName}역`;
+  const googleSearchQuery = `${stationNameWithSuffix} 주변 맛집`;
+  const googleSearchUrl = `https://www.google.com/search?q=${encodeURIComponent(
+    googleSearchQuery,
+  )}`;
   const formattedCoordinates = hasCoordinates
     ? `${station.latitude.toFixed(6)}, ${station.longitude.toFixed(6)}`
     : '위치 정보를 불러올 수 없습니다';
@@ -77,6 +85,20 @@ export function StationCard({ station }: StationCardProps) {
             markerLabel={station.name}
             ariaLabel={`${station.name} 위치 지도`}
           />
+          <div className="station-card__actions">
+            <a
+              className="station-card__search-link"
+              href={googleSearchUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`구글에서 ${googleSearchQuery} 검색`}
+            >
+              구글에서 {googleSearchQuery} 검색하기
+              <span aria-hidden="true" className="station-card__search-link-icon">
+                →
+              </span>
+            </a>
+          </div>
         </div>
       )}
     </article>


### PR DESCRIPTION
## Summary
- add a Google search query for each station to open results for nearby restaurants
- display a call-to-action link under the embedded map and style it to fit the card design
- adjust the search call-to-action with a warm gradient and arrow indicator to distinguish it from line chips

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd1272557083238f79f8c5854eb936