### PR TITLE
Add SEO meta tags for data place recommendations

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,30 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="랜덤 지하철 역을 뽑아 주변의 데이터 관련 장소와 추천 스폿을 빠르게 찾아보세요."
+    />
+    <meta
+      name="keywords"
+      content="데이터 장소 추천, 데이터 카페, 코워킹 스페이스, 랜덤 지하철, 데이터 작업"
+    />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="ko_KR" />
+    <meta property="og:title" content="랜덤 지하철 역 데이터 장소 추천" />
+    <meta
+      property="og:description"
+      content="지하철 역을 랜덤으로 선택하고 데이터 작업에 최적화된 장소를 추천받으세요."
+    />
+    <meta property="og:site_name" content="랜덤 지하철 역 뽑기" />
+    <meta property="og:url" content="https://random-subway.example.com" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="랜덤 지하철 역 데이터 장소 추천" />
+    <meta
+      name="twitter:description"
+      content="데이터 작업을 위한 최적의 장소를 랜덤 지하철 역 기반으로 추천해드립니다."
+    />
     <title>랜덤 지하철 역 뽑기</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add SEO-focused description, keywords, and robots meta tags to the root HTML
- provide Open Graph and Twitter card metadata tailored to data place recommendations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd378b7a1083239247988dc6974fbc